### PR TITLE
Update for Bazel 0.24.1

### DIFF
--- a/dart/build_rules/core.bzl
+++ b/dart/build_rules/core.bzl
@@ -34,7 +34,7 @@ def _dart_library_impl(ctx):
 
 dart_library_attrs = {
     "srcs": attr.label_list(allow_files=True, mandatory=True),
-    "data": attr.label_list(allow_files=True, cfg="data"),
+    "data": attr.label_list(allow_files=True),
     "deps": attr.label_list(providers=["dart"]),
     "license_files": attr.label_list(allow_files=True)
 }

--- a/dart/build_rules/internal.bzl
+++ b/dart/build_rules/internal.bzl
@@ -35,11 +35,11 @@ def assert_third_party_licenses(ctx):
 
 
 def collect_files(dart_ctx):
-  srcs = set(dart_ctx.srcs)
-  data = set(dart_ctx.data)
+  srcs = dart_ctx.srcs
+  data = dart_ctx.data
   for d in dart_ctx.transitive_deps.values():
-    srcs += d.dart.srcs
-    data += d.dart.data
+    srcs = srcs + d.dart.srcs
+    data = srcs + d.dart.data
   return (srcs, data)
 
 
@@ -54,7 +54,7 @@ def _collect_transitive_deps(deps):
   """
   transitive_deps = {}
   for dep in deps:
-    transitive_deps += dep.dart.transitive_deps
+    transitive_deps.update(dep.dart.transitive_deps)
     transitive_deps["%s" % dep.dart.label] = dep
   return transitive_deps
 
@@ -102,8 +102,8 @@ def _new_dart_context(label,
       label=label,
       package=package,
       lib_root=lib_root,
-      srcs=set(srcs or []),
-      data=set(data or []),
+      srcs=srcs or [],
+      data=data or [],
       deps=deps or [],
       transitive_deps=dict(transitive_deps or {}),
   )
@@ -119,8 +119,8 @@ def make_dart_context(label,
     package = _label_to_dart_package_name(label)
   if not lib_root:
     lib_root = "%s/lib/" % label.package
-  srcs = set(srcs or [])
-  data = set(data or [])
+  srcs = srcs or []
+  data = data or []
   deps = deps or []
   transitive_deps = _collect_transitive_deps(deps)
   return struct(
@@ -145,6 +145,8 @@ def _merge_dart_context(dart_ctx1, dart_ctx2):
          "  %s declares: %s\n" % (dart_ctx2.label, dart_ctx2.lib_root) +
          "Targets in the same package must declare the same lib_root")
 
+  transitive_deps = dart_ctx1.transitive_deps
+  transitive_deps.update(dart_ctx1.transitive_deps)
   return _new_dart_context(
       label=dart_ctx1.label,
       package=dart_ctx1.package,
@@ -152,7 +154,7 @@ def _merge_dart_context(dart_ctx1, dart_ctx2):
       srcs=dart_ctx1.srcs + dart_ctx2.srcs,
       data=dart_ctx1.data + dart_ctx2.data,
       deps=dart_ctx1.deps + dart_ctx2.deps,
-      transitive_deps=dart_ctx1.transitive_deps + dart_ctx2.transitive_deps,
+      transitive_deps=transitive_deps,
   )
 
 

--- a/dart/build_rules/repositories.bzl
+++ b/dart/build_rules/repositories.bzl
@@ -14,6 +14,8 @@
 
 """Repositories for Dart."""
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 
 _DART_SDK_BUILD_FILE = """
 package(default_visibility = [ "//visibility:public" ])
@@ -54,14 +56,14 @@ filegroup(
 
 
 def dart_repositories():
-  native.new_http_archive(
+  http_archive(
       name = "dart_linux_x86_64",
       url = "https://storage.googleapis.com/dart-archive/channels/stable/release/1.19.1/sdk/dartsdk-linux-x64-release.zip",
       sha256 = "de3634a5572b805172aa3544214a5b1ecf3d16a20956cd5cac3781863cbfdb0a",
       build_file_content = _DART_SDK_BUILD_FILE,
   )
 
-  native.new_http_archive(
+  http_archive(
       name = "dart_darwin_x86_64",
       url = "https://storage.googleapis.com/dart-archive/channels/stable/release/1.19.1/sdk/dartsdk-macos-x64-release.zip",
       sha256 = "bbcbf5a6c566b3a1a057129158982f4fba54c848e0c3ed4fcee7fdf85d53d885",

--- a/dart/build_rules/vm.bzl
+++ b/dart/build_rules/vm.bzl
@@ -90,7 +90,7 @@ _dart_vm_binary_attrs = {
     "script_args": attr.string_list(),
     "vm_flags": attr.string_list(),
     "srcs": attr.label_list(allow_files=True, mandatory=True),
-    "data": attr.label_list(allow_files=True, cfg="data"),
+    "data": attr.label_list(allow_files=True),
     "deps": attr.label_list(providers=["dart"]),
     "snapshot": attr.bool(default=True),
     "_dart_vm": attr.label(
@@ -235,7 +235,7 @@ _dart_vm_test_attrs = {
     "script_args": attr.string_list(),
     "vm_flags": attr.string_list(),
     "srcs": attr.label_list(allow_files=True, mandatory=True),
-    "data": attr.label_list(allow_files=True, cfg="data"),
+    "data": attr.label_list(allow_files=True),
     "deps": attr.label_list(providers=["dart"]),
     "_dart_vm": attr.label(
         allow_files=True,

--- a/dart/build_rules/web.bzl
+++ b/dart/build_rules/web.bzl
@@ -45,10 +45,11 @@ def dart2js_action(ctx, dart_ctx, script_file,
   out_script = build_dir_files[script_file.short_path]
 
   # Compute action inputs.
-  inputs = ctx.files._dart2js
-  inputs += ctx.files._dart2js_support
-  inputs += build_dir_files.values()
-  inputs += [package_spec]
+  inputs = (
+      ctx.files._dart2js +
+      ctx.files._dart2js_support +
+      build_dir_files.values() + [package_spec]
+  )
 
   # Compute dart2js args.
   dart2js_args = [
@@ -120,36 +121,6 @@ def _dart_web_application_impl(ctx):
   return struct()
 
 
-_dart_web_application_attrs = {
-    "script_file": attr.label(
-        allow_files=True, single_file=True, mandatory=True),
-    "srcs": attr.label_list(allow_files=True, mandatory=True),
-    "data": attr.label_list(allow_files=True, cfg="data"),
-    "deps": attr.label_list(providers=["dart"]),
-    "deferred_lib_count": attr.int(default=0),
-    # compiler flags
-    "checked": attr.bool(default=False),
-    "csp": attr.bool(default=False),
-    "dump_info": attr.bool(default=False),
-    "minify": attr.bool(default=True),
-    "preserve_uris": attr.bool(default=False),
-    # tools
-    "_dart2js": attr.label(
-        allow_files=True,
-        single_file=True,
-        executable=True,
-        cfg="host",
-        default=Label("//dart/build_rules/ext:dart2js")),
-    "_dart2js_support": attr.label(
-        allow_files=True,
-        default=Label("//dart/build_rules/ext:dart2js_support")),
-    "_dart2js_helper": attr.label(
-        allow_files=True,
-        single_file=True,
-        executable=True,
-        cfg="host",
-        default=Label("//dart/build_rules/tools:dart2js_helper")),
-}
 
 
 def _dart_web_application_outputs(dump_info, deferred_lib_count):
@@ -169,6 +140,35 @@ def _dart_web_application_outputs(dump_info, deferred_lib_count):
 
 dart_web_application = rule(
     implementation=_dart_web_application_impl,
-    attrs=_dart_web_application_attrs,
+    attrs={
+        "script_file": attr.label(
+            allow_files=True, single_file=True, mandatory=True),
+        "srcs": attr.label_list(allow_files=True, mandatory=True),
+        "data": attr.label_list(allow_files=True),
+        "deps": attr.label_list(providers=["dart"]),
+        "deferred_lib_count": attr.int(default=0),
+        # compiler flags
+        "checked": attr.bool(default=False),
+        "csp": attr.bool(default=False),
+        "dump_info": attr.bool(default=False),
+        "minify": attr.bool(default=True),
+        "preserve_uris": attr.bool(default=False),
+        # tools
+        "_dart2js": attr.label(
+            allow_files=True,
+            single_file=True,
+            executable=True,
+            cfg="host",
+            default=Label("//dart/build_rules/ext:dart2js")),
+        "_dart2js_support": attr.label(
+            allow_files=True,
+            default=Label("//dart/build_rules/ext:dart2js_support")),
+        "_dart2js_helper": attr.label(
+            allow_files=True,
+            single_file=True,
+            executable=True,
+            cfg="host",
+            default=Label("//dart/build_rules/tools:dart2js_helper")),
+    },
     outputs=_dart_web_application_outputs,
 )


### PR DESCRIPTION
Minimal set of quick and dirty tweaks to get these rules working under
Bazel 0.24.1.

Note that these rules still make use of Dart 1.19.1 and have not been
updated for Dart 2.