### PR TITLE
Minor updates to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,10 @@
 # WE'VE MOVED!
 
-These rules have moved to
-[a more permanent home](https://github.com/dart-lang/rules_dart) under the
-dart-lang organisation. Please update your bookmarks.
-
-This repo will remain until the `dart_proto_library` branch is merged upstream.
-
 # Dart rules
 
-**WARNING** These are in active development and are *not* production-ready.
-Expect frequent breaking changes.
+**WARNING** These rules had moved to [the dart-lang
+organisation](https://github.com/dart-lang/rules_dart) which was later
+deprecated and archived. They are maintained on an infrequent basis.
 
 ## Rules
 


### PR DESCRIPTION
The upstreamed dart-lang/rules_dart repo has been archived and is no
longer in sync with internal rules. This updates README.md to reflect
this.