### PR TITLE
Add continuous integration configuration

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,0 +1,48 @@
+---
+buildifier:
+  version: latest
+  warnings: "all"
+platforms:
+  ubuntu1604:
+    run_targets:
+    build_targets:
+    - "..."
+    test_flags:
+    - "--test_timeout=300"
+    test_targets:
+    - "..."
+  ubuntu1804:
+    run_targets:
+    build_targets:
+    - "..."
+    test_flags:
+    - "--test_timeout=300"
+    test_targets:
+    - "..."
+  ubuntu1804_nojava:
+    run_targets:
+    build_flags:
+    - "--javabase=@openjdk11_linux_archive//:runtime"
+    build_targets:
+    - "..."
+    test_flags:
+    - "--test_timeout=300"
+    - "--javabase=@openjdk11_linux_archive//:runtime"
+    test_targets:
+    - "..."
+  macos:
+    run_targets:
+    build_targets:
+    - "..."
+    test_flags:
+    - "--test_timeout=300"
+    test_targets:
+    - "..."
+  windows:
+    run_targets:
+    build_targets:
+    - "..."
+    test_flags:
+    - "--test_timeout=300"
+    test_targets:
+    - "..."


### PR DESCRIPTION
This mirrors existing continuous integration configuration in the
official Bazel repo, such as those in rules_cc, from which this config
has been copied.

Bazel uses its own continuous integration testing tooling which can be
found in Bazel's continuous-integration repo. That tooling is a wrapper
around the basic continuous integration pipeline tooling provided by
BuildKite.

Bazel's CI tooling: https://github.com/bazelbuild/continuous-integration
Example rules: https://github.com/bazelbuild/rules_cc
BuildKite: https://builtkite.com