### PR TITLE
Set Travis CI language to bash

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+language: bash
+
 sudo: required
 
 before_install:


### PR DESCRIPTION
This avoids downloading a pile of Ruby dependencies that we don't need.