### PR TITLE
Install Bazel via Ubuntu apt repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,11 @@ language: bash
 sudo: required
 
 before_install:
-  - wget https://github.com/bazelbuild/bazel/releases/download/1.0.1/bazel_1.0.1-linux-x86_64.deb
-  - sha256sum -c tools/bazel_1.0.1-linux-x86_64.deb.sha256
-  - sudo dpkg -i bazel_1.0.1-linux-x86_64.deb
+  - echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list
+  - sudo apt install curl
+  - curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
+  - sudo apt update
+  - sudo apt install bazel
 
 script:
   - tools/run_tests.sh


### PR DESCRIPTION
While this no longer locks the version of Bazel down in the
configuration, it guarantees we're running against latest stable
release. While we lose reproducibility, we gain a fair bit of
convenience.

The alternative would be to run a cron job that watches for new versions
of Bazel and generates, tests, and merges PRs that upgrade to them.