### PR TITLE
Delete bazel_1.0.1-linux-x86_64.deb.sha256

### DIFF
--- a/tools/bazel_1.0.1-linux-x86_64.deb.sha256
+++ b/tools/bazel_1.0.1-linux-x86_64.deb.sha256
@@ -1,1 +1,0 @@
-6b9cf2039f57dcf7fe8bc91e58c10f8bd5be49ae628341be08609d1c99b46148  bazel_1.0.1-linux-x86_64.deb


### PR DESCRIPTION
It looks like bazel 1 is being used but in reality this file is no longer used. Travis is taking the latest bazel release.