### PR TITLE
Ensure that run_tests.sh emits failure on failure

### DIFF
--- a/tools/run_tests.sh
+++ b/tools/run_tests.sh
@@ -4,20 +4,32 @@ echo
 echo "============================================================"
 echo "Building all targets."
 echo "============================================================"
-bazel build ...
+if ! bazel build ...; then
+  echo "============================================================"
+  echo "ERROR: bazel build ... failed."
+  echo "============================================================"
+  exit 1
+fi
 
 echo
 echo "============================================================"
 echo "Running tests."
 echo "============================================================"
-bazel test //examples/hello_lib:passing_test
+if ! bazel test //examples/hello_lib:passing_test; then
+  echo "============================================================"
+  echo "ERROR: bazel test //examples/hello_lib:passing_test failed."
+  echo "============================================================"
+  exit 1
+fi
 
 echo
 echo "============================================================"
 echo "Verifying that expected failures fail."
 echo "============================================================"
 if bazel test //examples/hello_lib:failing_test; then
-  echo "ERROR: Expected failure did not fail."
+  echo "============================================================"
+  echo "ERROR: bazel test //examples/hello_lib:failing_test did not fail."
+  echo "============================================================"
   exit 1
 fi
 


### PR DESCRIPTION
Previously, we verified that if the failing_test passed, the build would
fail, but neglected to check that the build or passing_test step
succeeded.