### PR TITLE
Update Travis install commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,22 +6,22 @@ os:
   - linux
   - osx
 
+dist: focal
+osx_image: xcode12.2
+
 addons:
-  homebrew:
+  apt:
+    sources:
+      - sourceline: "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8"
+        key_url: "https://bazel.build/bazel-release.pub.gpg"
     packages:
       - bazel
-
-before_install:
-  # Install Bazel on Linux.
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list; fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt install curl; fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -; fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt update; fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt install bazel; fi
-  # Install Bazel on macOS.
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew update; fi
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew cask install homebrew/cask-versions/adoptopenjdk8; fi
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install bazel; fi
+  homebrew:
+    update: true
+    taps:
+      - bazelbuild/tap
+    packages:
+      - bazelbuild/tap/bazel
 
 script:
   - tools/run_tests.sh


### PR DESCRIPTION
Cleaned up the Travis install steps to use the built-in `apt` and
`homebrew` commands to install bazel from the bazelbuild tap. This
avoids the manual OpenJDK and homebrew install steps in shell script.