### PR TITLE
Update build status badge to GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build and test
+name: Build
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Dart rules for Bazel
 ====================
 
-[![Build Status](https://travis-ci.org/cbracken/rules_dart.svg?branch=master)](https://travis-ci.org/cbracken/rules_dart)
+![Build Status](https://github.com/cbracken/rules_dart/actions/workflows/build.yml/badge.svg)
 
 **WARNING:** These rules are maintained on an infrequent basis. They were
 authored as the foundation for what became the


### PR DESCRIPTION
Migrate the build status badge from Travis CI to GitHub actions. This
should have been part of commit 8a30007, but I missed it.