### PR TITLE
Native support for arm64 Mac hosts

### DIFF
--- a/dart/BUILD
+++ b/dart/BUILD
@@ -6,6 +6,11 @@ config_setting(
 )
 
 config_setting(
+    name = "darwin_arm64",
+    values = {"host_cpu": "darwin_arm64"},
+)
+
+config_setting(
     name = "k8",
     values = {"host_cpu": "k8"},
 )

--- a/dart/build_rules/ext/BUILD
+++ b/dart/build_rules/ext/BUILD
@@ -3,6 +3,7 @@ package(default_visibility = ["//visibility:public"])
 filegroup(
     name = "dart_vm",
     srcs = select({
+        "//dart:darwin_arm64": ["@dart_darwin_arm64//:dart_vm"],
         "//dart:darwin": ["@dart_darwin_x86_64//:dart_vm"],
         "//dart:k8": ["@dart_linux_x86_64//:dart_vm"],
     }),
@@ -11,6 +12,7 @@ filegroup(
 filegroup(
     name = "dart2js",
     srcs = select({
+        "//dart:darwin_arm64": ["@dart_darwin_arm64//:dart2js"],
         "//dart:darwin": ["@dart_darwin_x86_64//:dart2js"],
         "//dart:k8": ["@dart_linux_x86_64//:dart2js"],
     }),
@@ -19,6 +21,7 @@ filegroup(
 filegroup(
     name = "dart2js_support",
     srcs = select({
+        "//dart:darwin_arm64": ["@dart_darwin_arm64//:dart2js_support"],
         "//dart:darwin": ["@dart_darwin_x86_64//:dart2js_support"],
         "//dart:k8": ["@dart_linux_x86_64//:dart2js_support"],
     }),

--- a/dart/build_rules/repositories.bzl
+++ b/dart/build_rules/repositories.bzl
@@ -58,6 +58,7 @@ def dart_repositories():
   sdk_channel = "stable"
   sdk_version = "2.17.0"
   linux_x64_sha = "57b8fd964e47c81d467aeb95b099a670ab7e8f54a1cd74d45bcd1fdc77913d86"
+  macos_arm64_sha = "5977f449d4841cc68945f54580acdbf526382c18dfd713b93a48bf77328c10c6"
   macos_x64_sha = "3f06b15101c852145608ecb7215746b51c8ff4bb6c72aa1424f3997debcdef1b"
 
   sdk_base_url = ("https://storage.googleapis.com/dart-archive/channels/" +
@@ -68,6 +69,13 @@ def dart_repositories():
       name = "dart_linux_x86_64",
       url = sdk_base_url + "dartsdk-linux-x64-release.zip",
       sha256 = linux_x64_sha,
+      build_file_content = _DART_SDK_BUILD_FILE,
+  )
+
+  http_archive(
+      name = "dart_darwin_arm64",
+      url = sdk_base_url + "dartsdk-macos-arm64-release.zip",
+      sha256 = macos_arm64_sha,
       build_file_content = _DART_SDK_BUILD_FILE,
   )
 

--- a/dart/build_rules/templates/BUILD
+++ b/dart/build_rules/templates/BUILD
@@ -3,6 +3,7 @@ package(default_visibility = ["//visibility:public"])
 filegroup(
     name = "dart_vm_binary",
     srcs = select({
+        "//dart:darwin_arm64": ["dart_vm_binary.sh"],
         "//dart:darwin": ["dart_vm_binary.sh"],
         "//dart:k8": ["dart_vm_binary.sh"],
     }),
@@ -19,6 +20,7 @@ filegroup(
 filegroup(
     name = "dart_vm_test",
     srcs = select({
+        "//dart:darwin_arm64": ["dart_vm_test.sh"],
         "//dart:darwin": ["dart_vm_test.sh"],
         "//dart:k8": ["dart_vm_test.sh"],
     }),
@@ -27,6 +29,7 @@ filegroup(
 filegroup(
     name = "dart_vm_test_coverage",
     srcs = select({
+        "//dart:darwin_arm64": ["dart_vm_test_coverage.sh"],
         "//dart:darwin": ["dart_vm_test_coverage.sh"],
         "//dart:k8": ["dart_vm_test_coverage.sh"],
     }),

--- a/dart/build_rules/tools/BUILD
+++ b/dart/build_rules/tools/BUILD
@@ -3,6 +3,7 @@ package(default_visibility = ["//visibility:public"])
 filegroup(
     name = "dart2js_helper",
     srcs = select({
+        "//dart:darwin_arm64": ["dart2js_helper.sh"],
         "//dart:darwin": ["dart2js_helper.sh"],
         "//dart:k8": ["dart2js_helper.sh"],
     }),

--- a/tools/roll_dart
+++ b/tools/roll_dart
@@ -41,6 +41,7 @@ class Channel(Enum):
 
 class Platform(Enum):
   LINUX_X64 = "linux-x64"
+  MACOS_ARM64 = "macos-arm64"
   MACOS_X64 = "macos-x64"
 
 
@@ -197,6 +198,7 @@ class RepositoryRules:
   RE_CHANNEL = re.compile(r'\s*sdk_channel = "(.*)"')
   RE_VERSION = re.compile(r'\s*sdk_version = "(.*)"')
   RE_LINUX_X64_SHA = re.compile(r'\s*linux_x64_sha = "(.*)"')
+  RE_MACOS_ARM64_SHA = re.compile(r'\s*macos_arm64_sha = "(.*)"')
   RE_MACOS_X64_SHA = re.compile(r'\s*macos_x64_sha = "(.*)"')
 
   def readlines(self):
@@ -224,6 +226,8 @@ class RepositoryRules:
         lines.append('  sdk_version = "%s"\n' % release.version)
       elif self.RE_LINUX_X64_SHA.match(line):
         lines.append('  linux_x64_sha = "%s"\n' % release.sdk_shasum(Platform.LINUX_X64))
+      elif self.RE_MACOS_ARM64_SHA.match(line):
+        lines.append('  macos_arm64_sha = "%s"\n' % release.sdk_shasum(Platform.MACOS_ARM64))
       elif self.RE_MACOS_X64_SHA.match(line):
         lines.append('  macos_x64_sha = "%s"\n' % release.sdk_shasum(Platform.MACOS_X64))
       else:


### PR DESCRIPTION
When running on arm64-based (Apple Silicon) host devices, we now detect
host_cpu `darwin_arm64` and download the arm64 Dart SDK.

Issue: https://github.com/cbracken/rules_dart/issues/77