### PR TITLE
Correctly handle transitive library dependencies

### DIFF
--- a/dart/build_rules/internal.bzl
+++ b/dart/build_rules/internal.bzl
@@ -145,8 +145,9 @@ def _merge_dart_context(dart_ctx1, dart_ctx2):
          "  %s declares: %s\n" % (dart_ctx2.label, dart_ctx2.lib_root) +
          "Targets in the same package must declare the same lib_root")
 
-  transitive_deps = dart_ctx1.transitive_deps
+  transitive_deps = {}
   transitive_deps.update(dart_ctx1.transitive_deps)
+  transitive_deps.update(dart_ctx2.transitive_deps)
   return _new_dart_context(
       label=dart_ctx1.label,
       package=dart_ctx1.package,

--- a/examples/goodbye_lib/lib/goodbye.dart
+++ b/examples/goodbye_lib/lib/goodbye.dart
@@ -1,3 +1,5 @@
 library goodbye;
 
-String sayGoodbye(String name) => 'Goodbye, $name!';
+import 'package:examples.greet_lib/greet.dart';
+
+String sayGoodbye(String name) => whisper('Goodbye, $name!');

--- a/examples/greet_lib/BUILD
+++ b/examples/greet_lib/BUILD
@@ -1,9 +1,9 @@
 load("//dart/build_rules:core.bzl", "dart_library")
+load("//dart/build_rules:vm.bzl", "dart_vm_test")
 
 package(default_visibility = ["//visibility:public"])
 
 dart_library(
-    name = "goodbye_lib",
-    srcs = ["lib/goodbye.dart"],
-    deps = ["//examples/greet_lib"],
+    name = "greet_lib",
+    srcs = ["lib/greet.dart"],
 )

--- a/examples/greet_lib/lib/greet.dart
+++ b/examples/greet_lib/lib/greet.dart
@@ -1,0 +1,5 @@
+library greet;
+
+String shout(String message) => message.toUpperCase();
+
+String whisper(String message) => message.toLowerCase();

--- a/examples/hello_bin/BUILD
+++ b/examples/hello_bin/BUILD
@@ -7,6 +7,7 @@ dart_vm_binary(
     srcs = ["bin/hello.dart"],
     script_file = "bin/hello.dart",
     deps = [
+        "//examples/goodbye_lib",
         "//examples/hello_lib",
     ],
 )
@@ -18,6 +19,7 @@ dart_vm_binary(
     script_args = ["foo", "bar"],
     vm_flags = ["--enable-asserts"],
     deps = [
+        "//examples/goodbye_lib",
         "//examples/hello_lib",
     ],
 )
@@ -39,6 +41,7 @@ dart_vm_binary(
     script_args = ["foo", "bar"],
     vm_flags = ["--enable-asserts"],
     deps = [
+        "//examples/goodbye_lib",
         "//examples/hello_lib",
     ],
     snapshot = True,

--- a/examples/hello_bin/bin/hello.dart
+++ b/examples/hello_bin/bin/hello.dart
@@ -1,7 +1,8 @@
 import 'package:examples.hello_lib/hello.dart';
+import 'package:examples.goodbye_lib/goodbye.dart';
 
 main(List<String> args) {
-  var greeting = sayHello("world");
-  print(greeting);
+  print(sayHello("world"));
   print("${args.length} arguments: ${args}");
+  print(sayGoodbye("world"));
 }

--- a/examples/hello_lib/BUILD
+++ b/examples/hello_lib/BUILD
@@ -3,9 +3,18 @@ load("//dart/build_rules:vm.bzl", "dart_vm_test")
 
 package(default_visibility = ["//visibility:public"])
 
+# Top-level library that verifies that library-library dependencies within a
+# package build successfully.
 dart_library(
     name = "hello_lib",
     srcs = ["lib/hello.dart"],
+    deps = [":emote_lib"],
+)
+
+dart_library(
+    name = "emote_lib",
+    srcs = ["lib/src/emote.dart"],
+    deps = ["//examples/greet_lib"],
 )
 
 dart_vm_test(

--- a/examples/hello_lib/lib/hello.dart
+++ b/examples/hello_lib/lib/hello.dart
@@ -1,3 +1,6 @@
 library hello;
 
-String sayHello(String name) => 'Hello, $name!';
+import 'src/emote.dart';
+
+/// Returns a greeting for the specified name.
+String sayHello(String name) => exclaim('Hello, $name');

--- a/examples/hello_lib/lib/src/emote.dart
+++ b/examples/hello_lib/lib/src/emote.dart
@@ -1,0 +1,6 @@
+library emote;
+
+import 'package:examples.greet_lib/greet.dart';
+
+/// Returns the input string, but louder.
+String exclaim(String message) => shout('$message!');


### PR DESCRIPTION
Previously, when generating the transitive closure of dependencies for a
tree of dependent dart_library targets, while generating a merged
dart context for targets, we attempted to mutate one of the input
contexts rather than generating a new list of transitive deps for the
new context. There was a separate bug where we only actually pulled
dependencies from one of the two contexts while merging and not both.

Added:
* Library-library dependency within the hello_lib package
* Library-library dependency between hello_lib and greet_lib package
* Library-library dependency between goodbye_lib and greet_lib package

The last two dependencies also ensure that diamond dependencies are
working correctly.

Issue: https://github.com/cbracken/rules_dart/issues/60